### PR TITLE
Fix rob command not subtracting coins correctly

### DIFF
--- a/extensions/commands/economy.py
+++ b/extensions/commands/economy.py
@@ -456,7 +456,7 @@ class economy(commands.Cog):
             else:
                 cash2 = int(robber_bank * percentage)
                 await DataManager.edit_user_data(
-                    interaction.user.id, "balance", robber_data["bank"] - cash2
+                    interaction.user.id, "bank", robber_data["bank"] - cash2
                 )
                 await interaction.response.send_message(
                     embed=discord.Embed(


### PR DESCRIPTION
The "rob" command previously was adding the bank balance (minus paid amount to police) to user's wallet when their bank balance was higher than wallet balance